### PR TITLE
Fix boilerplate in LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -175,18 +175,10 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2009-2014, Next Century Corporation.
+   Copyright 2009-2010, Texeltek Inc.
+   The United States Government has unlimited rights in this software, 
+   pursuant to the contracts under which it was developed.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Remove the Apache license appendix boilerplate and replace it with the correct information.

See: https://github.com/dotcloud/docker/commit/73596b00e053fedbf42f7abb87728e7176e5a95c for a similar commit.